### PR TITLE
Message Tracking

### DIFF
--- a/bottimus_schema.sql
+++ b/bottimus_schema.sql
@@ -124,3 +124,10 @@ CREATE TABLE IF NOT EXISTS `mute_data` (
   `active` tinyint(1) DEFAULT 1,
   PRIMARY KEY (`guild`, `member`, `expiry`)
 );
+
+CREATE TABLE IF NOT EXISTS `bottimus_messages` (
+  `discordid` varchar(64) NOT NULL,
+  `guild` varchar(64) NOT NULL,
+  `amount` int(11) DEFAULT NULL,
+  PRIMARY KEY (`discordid`, `guild`)
+);

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,6 +23,8 @@ export default class BottimusClient extends Client {
     public cooldowns: Map<string, Map<string, number>> = new Map()
     public serverSettings: Map<string, ServerSettings> = new Map()
 
+    public messageCounts: Map<string, Map<string, number>> = new Map()
+
     public eventsData: Event[] = []
     public guildsWithEvents: string[] = []
 
@@ -98,6 +100,11 @@ export default class BottimusClient extends Client {
         // Do not handle messages by bots
         if (message.author.bot) return
 
+        // Count messages in Fluffy Servers
+        if (!this.testingMode && message.guild.id == BottimusClient.primaryGuild) {
+            this.countMessage(message.member)
+        }
+
         // Do not handle messages if the bot is about to restart
         if (this.restarting) return
 
@@ -108,9 +115,6 @@ export default class BottimusClient extends Client {
         // Do not handle messages in DM
         if (message instanceof DMChannel) return
         const channel = message.channel as TextChannel
-
-        // Apply scanners to every message
-        // TODO
 
         // Check if the command is valid
         let isBottimusCommand = false
@@ -152,6 +156,18 @@ export default class BottimusClient extends Client {
         } catch (err) {
             message.channel.send(err.message)
         }
+    }
+
+    public countMessage(member: GuildMember) {
+        let guild = member.guild.id
+        let guild_counts = this.messageCounts.get(guild)
+        if (!guild_counts) {
+            guild_counts = new Map()
+            this.messageCounts.set(guild, guild_counts)
+        }
+
+        let amount = guild_counts.get(member.id) || 0
+        guild_counts.set(member.id, amount + 1)
     }
 
     public checkCooldown(command: Command, user: string) {

--- a/src/commands/dailyspin.ts
+++ b/src/commands/dailyspin.ts
@@ -87,6 +87,6 @@ export default {
                 incrementArcadeCredits(message.member.id, amount)
                 updateLastSpin(message.member.id, new Date())
             }
-        })
+        }, 7000)
     }
 }

--- a/src/commands/message_counts.ts
+++ b/src/commands/message_counts.ts
@@ -6,6 +6,7 @@ export default {
     name: 'messages',
     description: 'Show the top users in the server, by number of messages',
     cooldown: 15,
+    guilds: ['309951255575265280'],
 
     async execute(client: Client, message: Message, args: string[]) {
         if (args.length < 1 || args[0] != 'me') {

--- a/src/commands/message_counts.ts
+++ b/src/commands/message_counts.ts
@@ -1,6 +1,6 @@
 import { Client, Message } from "../command"
 import { queryHelper } from "../database"
-import { padOrTrim } from "../utils"
+import { padOrTrim, padOrTrimLeft } from "../utils"
 
 export default {
     name: 'messages',
@@ -16,8 +16,8 @@ export default {
             let text = results.reduce((acc, result, idx) => {
                 let display = result.username || '<unknown>'
                 const position = padOrTrim(`#${idx + 1}.`, 5)
-                const name = padOrTrim(display, 23)
-                const messages = padOrTrim(result.amount.toString(), 7)
+                const name = padOrTrim(display, 22)
+                const messages = padOrTrimLeft(result.amount.toString(), 7)
                 return acc + `${position}${name}${messages}\n`
             }, header) + '```'
 

--- a/src/commands/message_counts.ts
+++ b/src/commands/message_counts.ts
@@ -1,0 +1,30 @@
+import { Client, Message } from "../command"
+import { queryHelper } from "../database"
+import { padOrTrim } from "../utils"
+
+export default {
+    name: 'messages',
+    description: 'Show the top users in the server, by number of messages',
+    cooldown: 15,
+
+    async execute(client: Client, message: Message, args: string[]) {
+        if (args.length < 1 || args[0] != 'me') {
+            let results = await queryHelper('SELECT u.username, m.amount FROM bottimus_messages m LEFT JOIN bottimus_userdata u on m.discordid = u.discordid WHERE guild = ?ORDER BY m.amount DESC LIMIT 20;', [message.guild.id])
+
+            let header = 'Message counts are estimates.\n```yaml\nNum  Username             Messages\n----------------------------------\n'
+            let text = results.reduce((acc, result, idx) => {
+                let display = result.username || '<unknown>'
+                const position = padOrTrim(`#${idx + 1}.`, 5)
+                const name = padOrTrim(display, 23)
+                const messages = padOrTrim(result.amount.toString(), 7)
+                return acc + `${position}${name}${messages}\n`
+            }, header) + '```'
+
+            message.channel.send(text)
+        }
+
+        let my_messages = await queryHelper('SELECT amount FROM bottimus_messages WHERE discordid = ? AND guild = ?', [message.member.id, message.guild.id])
+        message.channel.send(`\`Your messages: ${my_messages[0].amount}\``)
+        client.updateCooldown(this, message.member.id)
+    }
+}

--- a/src/commands/reload.ts
+++ b/src/commands/reload.ts
@@ -1,4 +1,5 @@
 import { Client, Message } from "../command"
+import { loadEvents } from "../events"
 
 export default {
     name: 'reload',
@@ -12,5 +13,6 @@ export default {
         }
 
         client.loadServerSettings()
+        loadEvents(client)
     }
 }

--- a/src/commands/switchcode.ts
+++ b/src/commands/switchcode.ts
@@ -7,17 +7,17 @@ async function buildFriendsTable(client: Client, message: Message, gid: string) 
     const queryString = 'SELECT u.username, code FROM arcade_switchcode a LEFT JOIN bottimus_userdata u on a.discordid = u.discordid WHERE guild = ?'
     const results = await queryHelper(queryString, [gid])
 
-    let codeString = '__Switch Codes__\nTo add your code to this list, type `!switchcode SW-1111-2222-3333`\n\n```yaml\n'
+    let result
+    let header = '**Switch Codes**\nTo add your code to this list, type `!switchcode SW-1111-2222-3333`\n```yaml\n'
     if (results.length < 1) {
-        codeString += 'Nobody has listed their friend code yet - be the first!'
+        result = header + 'Nobody has listed their friend code yet - be the first!```'
+    } else {
+        result = results.reduce((acc, result) => {
+            const name = padOrTrim(result.username, 25)
+            return acc + `${name} ${result.code}\n`
+        }, header) + '```'
     }
-    for (const result of results) {
-        const name = padOrTrim(result.username, 25)
-        codeString += `${name} ${result.code}\n`
-    }
-
-    codeString += '```'
-    message.channel.send(codeString)
+    message.channel.send(result)
 }
 
 export default {

--- a/src/commands/triviascores.ts
+++ b/src/commands/triviascores.ts
@@ -5,6 +5,7 @@ import { padOrTrim, padOrTrimLeft } from "../utils"
 export default {
     name: 'triviascores',
     description: 'Generates a Trivia leaderboard\nYou can either view percentage or total: `!triviascores percentage` `!triviascores total`',
+    cooldown: 15,
 
     async execute(client: Client, message: Message, args: string[]) {
         // Friendly join multiple arguments for the name
@@ -33,10 +34,11 @@ export default {
             let display = result.username
             const position = padOrTrim(`#${idx + 1}.`, 5)
             const name = padOrTrim(display, 25)
-            const score = padOrTrimLeft(result.score.toString(), 5)
+            const score = padOrTrimLeft(result.score.toString(), 4)
             return acc + `${position}${name}${score}\n`
         }, header) + '```'
 
         message.channel.send(text)
+        client.updateCooldown(this, message.member.id)
     }
 }

--- a/src/commands/triviascores.ts
+++ b/src/commands/triviascores.ts
@@ -1,6 +1,6 @@
 import { Client, Message } from "../command"
 import { queryHelper } from "../database"
-import { padOrTrim } from "../utils"
+import { padOrTrim, padOrTrimLeft } from "../utils"
 
 export default {
     name: 'triviascores',
@@ -33,7 +33,7 @@ export default {
             let display = result.username
             const position = padOrTrim(`#${idx + 1}.`, 5)
             const name = padOrTrim(display, 25)
-            const score = padOrTrim(result.score.toString(), 5)
+            const score = padOrTrimLeft(result.score.toString(), 5)
             return acc + `${position}${name}${score}\n`
         }, header) + '```'
 

--- a/src/commands/triviascores.ts
+++ b/src/commands/triviascores.ts
@@ -28,19 +28,15 @@ export default {
 
         // Run the query
         const results = await queryHelper(queryString, [args[0]])
-        let codestring = '```yaml\nNum  Username                Score\n----------------------------------\n'
-        let i = 1
-        for (const result of results) {
+        let header = '```yaml\nNum  Username                Score\n----------------------------------\n'
+        let text = results.reduce((acc, result, idx) => {
             let display = result.username
-
-            const position = padOrTrim(`#${i}.`, 5)
+            const position = padOrTrim(`#${idx + 1}.`, 5)
             const name = padOrTrim(display, 25)
             const score = padOrTrim(result.score.toString(), 5)
-            codestring += `${position}${name}${score}\n`
-            i++
-        }
+            return acc + `${position}${name}${score}\n`
+        }, header) + '```'
 
-        codestring += '```'
-        message.channel.send(codestring)
+        message.channel.send(text)
     }
 }

--- a/src/commands/update_all_users.ts
+++ b/src/commands/update_all_users.ts
@@ -18,9 +18,8 @@ export default {
             return
         }
 
-        let forceMode = false
-
         // If arguments are specified, then search for those
+        let forceMode = false
         if (args.length >= 1) {
             for (let arg of args) {
                 if (arg == 'force') {
@@ -38,9 +37,19 @@ export default {
         // Fetch all the user IDs
         // Depending on if force mode is active, select a different set of IDs
         const partialQuery = 'SELECT userid FROM arcade_currency WHERE userid NOT IN (SELECT discordid FROM bottimus_userdata);'
+        const partialQuery2 = 'SELECT discordid AS userid FROM bottimus_messages WHERE discordid NOT IN (SELECT discordid FROM bottimus_userdata);'
         const forceQuery = 'SELECT userid FROM arcade_currency'
-        const queryString = forceMode ? forceQuery : partialQuery
-        const results = await queryHelper(queryString, [])
+
+        let results
+        if (forceMode) {
+            results = await queryHelper(forceQuery, [])
+        } else {
+            results = await queryHelper(partialQuery, [])
+            results = results.concat(await queryHelper(partialQuery2, []))
+        }
+
+        console.log(results)
+
         for (let result of results) {
             const user = await client.users.fetch(result.userid, false)
             updateUserData(user)

--- a/src/events.ts
+++ b/src/events.ts
@@ -155,6 +155,7 @@ export class Event {
 }
 
 export async function loadEvents(client: BottimusClient) {
+    client.eventsData = []
     const queryString = 'SELECT * FROM bottimus_events WHERE time > NOW() - INTERVAL 35 DAY AND cancelled = 0'
     const results = await queryHelper(queryString, [])
 

--- a/src/updaters/message_counts.ts
+++ b/src/updaters/message_counts.ts
@@ -1,0 +1,20 @@
+import { Client, Updater } from "../updater"
+import { queryHelper } from "../database"
+
+export default {
+    description: "Save message counts data to the database",
+    frequency: 5,
+
+    async execute(client: Client) {
+        console.log(client.messageCounts)
+
+        client.messageCounts.forEach(async (guild_counts, guild_id) => {
+            guild_counts.forEach(async (count, member_id) => {
+                const queryString = 'INSERT INTO bottimus_messages VALUES(?, ?, ?) ON DUPLICATE KEY UPDATE amount = amount + VALUES(amount)'
+                await queryHelper(queryString, [member_id, guild_id, count])
+            })
+        })
+
+        client.messageCounts = new Map()
+    }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,3 +78,8 @@ export function padOrTrim(string: string, length: number): string {
     const trimmed = string.length > length ? string.substring(0, length) : string
     return trimmed.padEnd(length, ' ')
 }
+
+export function padOrTrimLeft(string: string, length: number): string {
+    const trimmed = string.length > length ? string.substring(0, length) : string
+    return trimmed.padStart(length, ' ')
+}


### PR DESCRIPTION
This PR adds support for message counting into Bottimus. While we can't get backlog data, we can enter any previous message counts manually and then use Bottimus to roughly track messages going forward. Currently, Bottimus is more than 99.5% accurate at tracking message counts.

This also adds a neat leaderboard of message counts, along with some minor changes to table formatting.